### PR TITLE
fix: filter empty URLs from file list to prevent crash on trailing newline

### DIFF
--- a/python/scripts/daac_data_download_python/DAACDataDownload.py
+++ b/python/scripts/daac_data_download_python/DAACDataDownload.py
@@ -28,9 +28,7 @@ files = args.files        # Define file(s) to download from the LP DAAC Data Poo
 # Create a list of files to download based on input type of files above
 if files.endswith('.txt') or files.endswith('.csv'):
     with open(files, 'r') as f:
-        fileList = f.read().splitlines() # If input is text/csv file with file URLs
-    
-    # fileList = open(files, 'r').readlines().splitlines()  
+        fileList = [url for url in f.read().splitlines() if url.strip()] # If input is text/csv file with file URLs
 elif isinstance(files, str):
     fileList = [files]                       # If input is a single file
 # Check if the directory exists


### PR DESCRIPTION
Fixes #39.

## Problem
`DAACDataDownload.py` split the URL file using `splitlines()`, which — when the file ends with a newline (as most text editors produce) — yields an empty string `''` at the end of the list. Passing that empty string to `earthaccess.download()` caused an unhandled crash.

## Fix
Filter out blank / whitespace-only lines when reading the URL list:

```python
# Before
fileList = f.read().splitlines()

# After
fileList = [url for url in f.read().splitlines() if url.strip()]
```

This is a one-line change that also handles lines containing only whitespace (e.g. Windows `\r` artifacts), making the script robust to any normal text file.

## Testing
```python
# Simulate a file with trailing newline (as any text editor would produce)
with open('test_urls.txt', 'w') as f:
    f.write('https://example.com/file1.tif\nhttps://example.com/file2.tif\n')

with open('test_urls.txt', 'r') as f:
    fileList = [url for url in f.read().splitlines() if url.strip()]

print(fileList)  # ['https://example.com/file1.tif', 'https://example.com/file2.tif']
print(len(fileList))  # 2  (not 3)
```